### PR TITLE
add ensure_correct_user

### DIFF
--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -1,5 +1,6 @@
 class Users::UsersController < ApplicationController
 	before_action :authenticate_user!, except: :show
+	before_action :ensure_correct_user, except: :show
 
 	def show
 		@user = User.find(params[:id])
@@ -39,4 +40,10 @@ class Users::UsersController < ApplicationController
 		params.require(:user).permit(:id, :email, :name, 
 			:telephone_number, :is_quit, :image, :introduction)
 	end
+
+	def ensure_correct_user
+    @user = User.find_by(params[:id])
+    if @user.id != @current_user.id
+      redirect_to root_path
+  end
 end

--- a/log/development.log
+++ b/log/development.log
@@ -10556,3 +10556,20 @@ DEPRECATION WARNING: Dangerous query method (method whose arguments are used as 
 Completed 200 OK in 3756ms (Views: 3518.3ms | ActiveRecord: 21.8ms)
 
 
+Started GET "/" for 10.0.2.2 at 2019-09-26 10:38:42 +0000
+Cannot render console from 10.0.2.2! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
+Processing by Users::RestaurantsController#index as HTML
+  [1m[36mUser Load (8.2ms)[0m  [1m[34mSELECT  "users".* FROM "users" WHERE "users"."id" = ? ORDER BY "users"."id" ASC LIMIT ?[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/users/restaurants_controller.rb:8
+DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "count(restaurant_id) desc". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from index at /vagrant/stock_gourmet/app/controllers/users/restaurants_controller.rb:14)
+  [1m[35m (8.1ms)[0m  [1m[34mSELECT  "favorites"."restaurant_id" FROM "favorites" GROUP BY "favorites"."restaurant_id" ORDER BY count(restaurant_id) desc LIMIT ?[0m  [["LIMIT", 10]]
+  ↳ app/controllers/users/restaurants_controller.rb:14
+  Rendering users/restaurants/index.html.erb within layouts/application
+  [1m[36mStation Load (6.9ms)[0m  [1m[34mSELECT DISTINCT "stations".* FROM "stations"[0m
+  ↳ app/views/users/restaurants/index.html.erb:8
+  Rendered users/restaurants/index.html.erb within layouts/application (27.8ms)
+  Rendered layouts/_users_header.html.erb (4.5ms)
+  Rendered layouts/_footer.html.erb (2.9ms)
+Completed 200 OK in 3657ms (Views: 3413.6ms | ActiveRecord: 23.2ms)
+
+


### PR DESCRIPTION
・users/usersブランチがなくなったため、代わりのブランチを作成
・ログインしているユーザーが他のユーザーの編集ページや退会ページに遷移させないように設定